### PR TITLE
more edits to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,52 +4,52 @@
 
 This repository includes software to quantitatively test the relation between the weak lensing shear bias and the modeling error of PSF higher order moments (beyond second).
 
-It is based on the following paper:
- - Impact of Point Spread Function Higher Moments Error on Weak Gravitational Lensing; Zhang and Mandelbaum for LSST (2021) https://arxiv.org/abs/2107.05644
+It is based on the following papers:
+ - Impact of Point Spread Function Higher Moments Error on Weak Gravitational Lensing; Zhang and Mandelbaum for LSST (2022), MNRAS - [ADS entry](https://ui.adsabs.harvard.edu/abs/2022MNRAS.510.1978Z/abstract)
  - Impact of Point Spread Function Higher Moments Error on Weak Gravitational Lensing II: A Comprehensive Study; Zhang et al. (2022) *in prep.* to be released in May 2022.
 
- This code has the following functionalities:
+ This code has functionality to do the following tasks:
  - change PSF second and higher moments through shapelet decomposition
  - conduct shear measurement for galaxy 90-deg rotated pairs, for the true and model PSF
  - measure the higher moments of the PSF
  - measure the two point correlation functions of the PSF moments residuals
- - fisher forecast for the unbiased and biased data vector (see https://github.com/hsnee/PZ_project)
+ - carry out a Fisher forecast for the unbiased and biased data vector (see https://github.com/hsnee/PZ_project)
 
-## Installment
+## Installation
 
-Standardized installment is not available at the moment, please do
+Standardized installation is not available at the moment. Please do
 ```
 git clone https://github.com/LSSTDESC/PSFHOME.git
 ```
-and install the dependency in a conda environment with python 3. 
+and install the dependencies in a conda environment with python 3. 
 
-## Guideboard
+## Guide to repository contents
 
-Class objects and help function can be found in the folder "./psfhome"
-- ``HOMExShapeletPair.py`` is the class to do single galaxy simulations to compute the shear response to any PSF higher moments. 
-- ``great3pipe.py`` is a class that do single galaxy simulation for the GREAT3 galaxies. https://arxiv.org/abs/1404.1593
-- ``homesm.py`` is the class to do single galaxy simulations to compute the shear response to radial kurtosis. 
-- ``metasm.py`` is the class to do metacalibration, but is not presented in the paper. 
-- ``moments.py``is a class that allows the user to change the PSF higher moments at their wish, using shapelet decomposition. This class also contains the function for measuring higher moments, called `get_all_moments()`.
+Class objects and helper functions can be found in the folder "./psfhome"
+- ``HOMExShapeletPair.py`` defines a class to do single galaxy simulations to compute the shear response to any PSF higher moments. 
+- ``great3pipe.py`` defines a class that carries out single galaxy simulation for the [GREAT3](https://arxiv.org/abs/1404.1593) galaxy sample. 
+- ``homesm.py`` defines a class to carry out single galaxy simulations to compute the shear response to radial kurtosis. 
+- ``metasm.py`` defines a class to measure shear for simulated images using metacalibration with ngmix, but it is not presented in the paper. 
+- ``moments.py``defines a class that allows the user to change the PSF higher moments as they wish, using shapelet decomposition. This class also contains the function for measuring higher moments, called `get_all_moments()`.
 
 
 Data are analyzed in the notebooks in the folder "./notebooks"
-- ``Additive_bpd_tomographic.ipynb`` is a notebook that compute the additive bias on the DC2 cosmic shear 2PCF. 
+- ``Additive_bpd_tomographic.ipynb`` is a notebook that computes the additive bias on the DC2 cosmic shear 2PCF. 
 - ``CorrGRF`` is a notebook for generating Gaussian random fields for the DC2 galaxies. 
 - ``HSC_higher_moments_analysis`` is a notebook for analysis of the HSC PSF higher moments and their residuals
 - ``HSC_moment_measure_pdr1`` is a notebook for measuring the PSF higher moments of the HSC stars and PSFs.
-- ``Single-simulation`` is a notebook for conducting single galaxy simulation
-- ``bpd_simulation``is a notebook to compute the additive shear response for a grid of bulge-disk galaxy, which is then used to compute the shear response for the CosmoDC2 galaxies. 
-- ``fisher_forecast`` is a notebook that conduct fisher forecast to predict the cosmology parameters bias induced by the PSF higher moments. 
+- ``Single-simulation`` is a notebook for conducting single galaxy simulations
+- ``bpd_simulation``is a notebook to compute the additive shear response for a grid of bulge-disk galaxy parameters, which is then used to compute the shear response for the CosmoDC2 galaxies. 
+- ``fisher_forecast`` is a notebook that conducts a Fisher forecast to predict the cosmological parameters biases induced by the PSF higher moments if their impact on shear is not modeled. 
 
 
 Figure can be found in the "./plots"
-- ``All_plots.ipynb`` is a notebook that reproduce all the plots in the paper. Users are welcomed to play with it. (many data needed are stored in ./plots/pickle)
+- ``All_plots.ipynb`` is a notebook that reproduces all plots in the second paper. Users are welcomed to play with it. (The necessary data are stored in ./plots/pickle)
 
 
 ## Contact us
 
-Please contact Tianqing Zhang (tianqinz "at" andrew.cmu.edu), if you need help for using the code. 
+Please contact Tianqing Zhang (tianqinz "at" andrew.cmu.edu), if you need help using the code. 
 
 Please use the [issues](https://github.com/LSSTDESC/PSFHOME/issues) on this repository to suggest changes, request support, or otherwise contact the developer.
 


### PR DESCRIPTION
This PR has a few more edits for clarity.  A note about one change: it's better to refer to the published versions of paper where possible, as it signals that the paper has gone through peer review.

I strongly recommend listing the dependencies in the README rather than telling people to install dependencies and making them go through all the helper files to figure out what they are.  It makes the README a little more useful in practice.